### PR TITLE
Feature/dynamic trip duration

### DIFF
--- a/components/NewTripForm/index.js
+++ b/components/NewTripForm/index.js
@@ -8,16 +8,34 @@ export default function NewTripForm() {
 
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+  const [tripDurationInDays, setTripDurationInDays] = useState(0);
 
-  // update startDate state value at onChange attribute of "start-date" input field
+  // handler for the onChange attribute of "start-date" input field
   function handleStartDateChange(event) {
     const startDateValue = event.target.value;
     setStartDate(startDateValue);
+    calculateTripDuration(startDateValue, endDate); //the second argument "endDate" is the useState value
   }
-  // update endDate state value at onChange attribute of "end-date" input field
+  // handler for the onChange attribute of "end-date" input field
   function handleEndDateChange(event) {
     const endDateValue = event.target.value;
     setEndDate(endDateValue);
+    calculateTripDuration(startDate, endDateValue); // the first argument "startDate" is the useState value
+  }
+
+  // calculate trip duration in days based on the input values of the form fields "start-date" and "end-date"
+  function calculateTripDuration(start, end) {
+    if (start && end) {
+      const startObject = new Date(start); // transforms the "start" argument into Date format which is needed to make calculations with dates
+      const endObject = new Date(end);
+      const durationInMilliseconds = endObject - startObject; // Date calculation in javascript is by default done in milliseconds. In the next line I converted the milliseconds in days.
+      const durationInDays = Math.floor(
+        durationInMilliseconds / (1000 * 60 * 60 * 24) + 1 // the + 1 is needed to also count the day of the start date
+      );
+      setTripDurationInDays(durationInDays);
+    } else {
+      setTripDurationInDays(0);
+    }
   }
 
   // Create a minimumEndDate used for the min attribute of the date input field "end-date", so that the end-date can't be earlier than the start-date of the trip
@@ -29,9 +47,6 @@ export default function NewTripForm() {
   const maximumStartDate = endDate
     ? new Date(endDate).toISOString().slice(0, 10)
     : "";
-
-  // default value till flexible trip duration will be implemented
-  const tripDurationInDays = 3;
 
   function handleSubmit(event) {
     event.preventDefault();

--- a/components/NewTripForm/index.js
+++ b/components/NewTripForm/index.js
@@ -4,6 +4,8 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 export default function NewTripForm() {
+  const router = useRouter();
+
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
@@ -30,7 +32,6 @@ export default function NewTripForm() {
 
   // default value till flexible trip duration will be implemented
   const tripDurationInDays = 3;
-  const router = useRouter();
 
   function handleSubmit(event) {
     event.preventDefault();
@@ -83,7 +84,7 @@ export default function NewTripForm() {
     router.push(`/my-trips/${newTripData.slug}`);
   }
 
-  // The inputs fields "Day title" and "Activities" need to be displayed based on the duration of the trip in days. So I use a loop for that and call the function which returns the right amount of input fields in line 45
+  // The inputs fields "Day title" and "Activities" need to be displayed based on the duration of the trip in days. So I use a loop for that and call the function which returns the right amount of input fields in the <fieldset aria-describedby="description">{createMultipleDays()}</fieldset> of my form
   function createMultipleDays() {
     const tripDays = [];
 

--- a/components/NewTripForm/index.js
+++ b/components/NewTripForm/index.js
@@ -1,8 +1,33 @@
 import styled from "styled-components";
 import { trips } from "../../lib/data";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 export default function NewTripForm() {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  // update startDate state value at onChange attribute of "start-date" input field
+  function handleStartDateChange(event) {
+    const startDateValue = event.target.value;
+    setStartDate(startDateValue);
+  }
+  // update endDate state value at onChange attribute of "end-date" input field
+  function handleEndDateChange(event) {
+    const endDateValue = event.target.value;
+    setEndDate(endDateValue);
+  }
+
+  // Create a minimumEndDate used for the min attribute of the date input field "end-date", so that the end-date can't be earlier than the start-date of the trip
+  const minimumEndDate = startDate
+    ? new Date(startDate).toISOString().slice(0, 10) //new Date(startDate) creates a new date based on the value of startDate. This new date needs to be formatted to be excepted by the min attribute of the input field "end-date". The formatting is done by .toISOString(). So far the string would look like this: 2023-06-07T00:00:00.000Z. The .slice(0, 10) extracts the first 11 characters of the string, which then looks like this: 2023-06-07
+    : "";
+
+  // Create a maximunStartDate used for the max attribute of the date input field "start-date", so that the start-date can't be later than the end-date of the trip
+  const maximumStartDate = endDate
+    ? new Date(endDate).toISOString().slice(0, 10)
+    : "";
+
   // default value till flexible trip duration will be implemented
   const tripDurationInDays = 3;
   const router = useRouter();
@@ -103,10 +128,24 @@ export default function NewTripForm() {
           />
 
           <label htmlFor="start-date">Start date:</label>
-          <input type="date" name="start-date" id="start-date" required />
+          <input
+            type="date"
+            name="start-date"
+            id="start-date"
+            onChange={handleStartDateChange}
+            max={maximumStartDate}
+            required
+          />
 
           <label htmlFor="end-date">End date: </label>
-          <input type="date" name="end-date" id="end-date" required />
+          <input
+            type="date"
+            name="end-date"
+            id="end-date"
+            onChange={handleEndDateChange}
+            min={minimumEndDate}
+            required
+          />
         </StyledFieldSet>
         <ContainerCenterElement>
           <h2 id="description">Trip Days</h2>

--- a/components/NewTripForm/index.js
+++ b/components/NewTripForm/index.js
@@ -38,15 +38,11 @@ export default function NewTripForm() {
     }
   }
 
-  // Create a minimumEndDate used for the min attribute of the date input field "end-date", so that the end-date can't be earlier than the start-date of the trip
-  const minimumEndDate = startDate
-    ? new Date(startDate).toISOString().slice(0, 10) //new Date(startDate) creates a new date based on the value of startDate. This new date needs to be formatted to be excepted by the min attribute of the input field "end-date". The formatting is done by .toISOString(). So far the string would look like this: 2023-06-07T00:00:00.000Z. The .slice(0, 10) extracts the first 11 characters of the string, which then looks like this: 2023-06-07
-    : "";
+  // Create minimumEndDate for min attribute of date input field "end-date", so that the end-date can't be earlier than the start-date of the trip
+  const minimumEndDate = startDate ? startDate : "";
 
-  // Create a maximunStartDate used for the max attribute of the date input field "start-date", so that the start-date can't be later than the end-date of the trip
-  const maximumStartDate = endDate
-    ? new Date(endDate).toISOString().slice(0, 10)
-    : "";
+  // Create maximunStartDate for max attribute of date input field "start-date", so that the start-date can't be later than the end-date of the trip
+  const maximumStartDate = endDate ? endDate : "";
 
   function handleSubmit(event) {
     event.preventDefault();

--- a/components/NewTripForm/index.js
+++ b/components/NewTripForm/index.js
@@ -113,7 +113,6 @@ export default function NewTripForm() {
             name={`title-${i}`}
             id={`title-${i}`}
             maxLength={60}
-            required
           />
 
           <label htmlFor={`activities-${i}`}>{`Activities:`}</label>
@@ -122,7 +121,6 @@ export default function NewTripForm() {
             id={`activities-${i}`}
             maxLength={500}
             rows={4}
-            required
           ></textarea>
         </StyledFieldSet>
       );


### PR DESCRIPTION
Please check this PR.

`When checking my first commit have a look at my last commit too as it simplifies my first commit by a huge margin.`

The User Story got an acceptance criteria of:
"When changing the Start or End date, the form directly updates the amount of displayed trip days"

This criteria can only be true when a date was already picked for both fields Start date and End date, as the form uses those fields to calculate the amount of trip day cards it needs to display.